### PR TITLE
Support for 1-Bit color depth and ignore transparency

### DIFF
--- a/led-badge-11x44.py
+++ b/led-badge-11x44.py
@@ -329,7 +329,6 @@ def bitmap_img(file):
         bit_val = 0
         x = 8*col+bit
         pixel_color = im.getpixel( (x, row) )
-        print(pixel_color)
         if isinstance(pixel_color, tuple):
           monochrome_color = sum(pixel_color[:3]) / len(pixel_color[:3])
         elif isinstance(pixel_color, int):

--- a/led-badge-11x44.py
+++ b/led-badge-11x44.py
@@ -328,7 +328,15 @@ def bitmap_img(file):
       for bit in range(8):
         bit_val = 0
         x = 8*col+bit
-        if x < im.width and sum(im.getpixel( (x, row) )) > 384:
+        pixel_color = im.getpixel( (x, row) )
+        print(pixel_color)
+        if isinstance(pixel_color, tuple):
+          monochrome_color = sum(pixel_color) / len(pixel_color)
+        elif isinstance(pixel_color, int):
+          monochrome_color = pixel_color
+        else:
+          sys.exit("%s: Unknown pixel format detected (%s)!" % (file, pixel_color))
+        if x < im.width and monochrome_color > 127:
           bit_val = 1 << (7-bit)
         byte_val += bit_val
       buf.append(byte_val)

--- a/led-badge-11x44.py
+++ b/led-badge-11x44.py
@@ -331,7 +331,7 @@ def bitmap_img(file):
         pixel_color = im.getpixel( (x, row) )
         print(pixel_color)
         if isinstance(pixel_color, tuple):
-          monochrome_color = sum(pixel_color) / len(pixel_color)
+          monochrome_color = sum(pixel_color[:3]) / len(pixel_color[:3])
         elif isinstance(pixel_color, int):
           monochrome_color = pixel_color
         else:


### PR DESCRIPTION
I run into the problem by accident while a generated an animation in 1-Bit mode (since I only need those colors).
```
using [LSicroelectronics LS32 Custm HID] bus=2 dev=11
fetching bitmap from file ../strip.png -> (1536 x 11)
Traceback (most recent call last):
  File "led-badge-11x44.py", line 462, in <module>
    msgs.append(bitmap(arg))
  File "led-badge-11x44.py", line 345, in bitmap
    return bitmap_text(arg)
  File "led-badge-11x44.py", line 304, in bitmap_text
    text = re.sub(r':([^:]*):', colonrepl, text)
  File "/usr/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "led-badge-11x44.py", line 299, in colonrepl
    bitmap_preloaded.append(bitmap_img(name))
  File "led-badge-11x44.py", line 331, in bitmap_img
    if x < im.width and sum(im.getpixel( (x, row) )) > 384:
TypeError: 'int' object is not iterable
```
The pixel was here simply an int instead of a tuple. Even if the tuple would've contained one element, all pixels would've been recognized black anyway.

The changes also include discarding the alpha value which would've been able to change the calculated average color, too.

Great software btw!