### PR TITLE
Fix : check for image overflow

### DIFF
--- a/led-badge-11x44.py
+++ b/led-badge-11x44.py
@@ -331,17 +331,17 @@ def bitmap_img(file):
       for bit in range(8):      # [0..7]
         bit_val = 0
         x = 8*col+bit
-        if x < im.width:
-          pixel_color = im.getpixel( (x, row) )
-          if isinstance(pixel_color, tuple):
-            monochrome_color = sum(pixel_color[:3]) / len(pixel_color[:3])
-          elif isinstance(pixel_color, int):
-            monochrome_color = pixel_color
-          else:
-            sys.exit("%s: Unknown pixel format detected (%s)!" % (file, pixel_color))
-          if monochrome_color > 127:
-            bit_val = 1 << (7-bit)
-          byte_val += bit_val
+        if x < im.width and row < im.height:
+            pixel_color = im.getpixel( (x, row) )
+            if isinstance(pixel_color, tuple):
+              monochrome_color = sum(pixel_color[:3]) / len(pixel_color[:3])
+            elif isinstance(pixel_color, int):
+              monochrome_color = pixel_color
+            else:
+              sys.exit("%s: Unknown pixel format detected (%s)!" % (file, pixel_color))
+            if x < im.width and monochrome_color > 127:
+              bit_val = 1 << (7-bit)
+            byte_val += bit_val
       buf.append(byte_val)
   im.close()
   return (buf, cols)

--- a/led-badge-11x44.py
+++ b/led-badge-11x44.py
@@ -46,6 +46,7 @@
 # v0.8, 2019-05-23, jw  Support usb.core on windows via libusb-win32
 # v0.9, 2019-07-17, jw  Support 48x12 configuration too.
 # v0.10, 2019-09-09, jw Support for loading monochrome images. Typos fixed.
+# v0.11, 2019-09-29, jw New option --brightness added.
 
 import sys, os, re, time, argparse
 from datetime import datetime
@@ -77,7 +78,7 @@ or
     sys.exit(1)
 
 
-__version = "0.10"
+__version = "0.11"
 
 font_11x44 = (
   # 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -496,7 +497,7 @@ else:
   print("Type: 11x44")
 
 buf = array('B')
-buf.extend(header(list(map(lambda x: x[1], msgs)), args.speed, args.mode, args.blink, args.ants, args.brightness))
+buf.extend(header(list(map(lambda x: x[1], msgs)), args.speed, args.mode, args.blink, args.ants, int(args.brightness)))
 
 for msg in msgs:
   buf.extend(msg[0])


### PR DESCRIPTION
The script keeps crashing when I export PNG from photoshop even if the finder gives me the right size. 

This is correcting the issue 

